### PR TITLE
Override default quit event handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Rust-Pong"
-version = "0.6.1"
+version = "1.0.0"
 authors = ["Vianpyro"]
 edition = "2024"
 

--- a/src/main_state.rs
+++ b/src/main_state.rs
@@ -256,6 +256,18 @@ impl event::EventHandler for MainState {
         canvas.finish(context)?;
         Ok(())
     }
+
+    fn quit_event(&mut self, _ctx: &mut Context) -> GameResult<bool> {
+        // If we're on the menu, allow the quit to proceed (return Ok(false)).
+        // Otherwise, return to the menu and cancel the quit (return Ok(true)).
+        match &self.state {
+            GameState::Menu => Ok(false),
+            _ => {
+                self.state = GameState::Menu;
+                Ok(true)
+            }
+        }
+    }
 }
 
 impl MainState {
@@ -352,7 +364,7 @@ impl MainState {
         self.draw_centered_title(canvas, context, winner_text, Color::WHITE)?;
 
         // Press to continue
-        let mut continue_text = Text::new("SPACE/ENTER: Menu   |   R: Restart   |   Esc: Quit");
+        let mut continue_text = Text::new("SPACE/ENTER: Menu   |   R: Restart   |   Esc: Menu");
         continue_text.set_scale(screen_height / 30.0);
         let continue_dimensions = continue_text.measure(context)?;
         let continue_position = Vec2::new((screen_width - continue_dimensions.x) / 2.0, screen_height * 0.65);
@@ -379,7 +391,7 @@ impl MainState {
         self.draw_centered_title(canvas, context, "Paused", Color::WHITE)?;
 
         // Hints
-        let mut hint = Text::new("P: Resume   |   Esc: Quit");
+        let mut hint = Text::new("P: Resume   |   Esc: Menu");
         hint.set_scale(screen_height / 30.0);
         let hint_dimensions = hint.measure(context)?;
         let hint_position = Vec2::new((screen_width - hint_dimensions.x) / 2.0, screen_height * 0.65);


### PR DESCRIPTION
## Description

- Override quit event handling and update menu hints.

## Related Issues

- Closes #15

## Changes Made

- List the main changes made in this PR:
  - [x] Override quit event handling in the Main State to allow using the `escape` key to return to the main menu
  - [x] Update the pause UI
  - [x] Update the game over UI

## How to Test

- Steps to test the changes:

1. Run the project
2. Start a game
3. Pause it
4. Press `escape`
5. You should be back to the main menu

## Checklist

- [x] My code follows the project's coding style.
- [x] I have performed a self-review of my code.
- [ ] I have added necessary tests (if applicable).
- [x] I have documented my changes (if necessary).

## Additional Context

- Overrides ggez's default quit event handling to limit quitting the program only when on the main menu