### PR TITLE
Fix inverted player controls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Rust-Pong"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Vianpyro"]
 edition = "2024"
 

--- a/src/player/player_type.rs
+++ b/src/player/player_type.rs
@@ -41,7 +41,7 @@ impl PlayerType {
     pub fn create_controller_for_player(&self, player: Player) -> Box<dyn Controller> {
         match self {
             PlayerType::Human => {
-                if player == Player::Right {
+                if player == Player::Left {
                     Box::new(HumanController::new(KeyCode::W, KeyCode::S))
                 } else {
                     Box::new(HumanController::new(KeyCode::Up, KeyCode::Down))


### PR DESCRIPTION
## Description

Fixed inverted player controls. The left player now correctly uses **W/S**, and the right player uses **Up/Down**, matching standard Pong controls.

## Related Issues

- Closes #18

## Changes Made

- [x] Corrected conditional in player controller assignment:
  - Changed `if player == Player::Right` to `if player == Player::Left`
- [x] Verified both players’ input mappings correspond to their on-screen sides

## Screenshots (if applicable)

N/A -- gameplay behavior fix only.

## How to Test

1. Launch the game.
2. Move the **left paddle** using **W** and **S**.
3. Move the **right paddle** using **Up** and **Down**.
4. Confirm each player’s controls respond correctly and independently.

## Checklist

- [x] My code follows the project's coding style.
- [x] I have performed a self-review of my code.
- [x] I have tested the fix manually.
- [ ] I have documented my changes (if necessary).

## Additional Context

Simple one-line fix to align player input mapping with expected behavior.
